### PR TITLE
Don't compress files by default. --compress must be provided in order to compress files. No need for --no-compress option.

### DIFF
--- a/soundcloud_cli/cli.py
+++ b/soundcloud_cli/cli.py
@@ -186,8 +186,6 @@ def main():
     upload_parser.add_argument('filename', help='filename to upload')
     upload_parser.add_argument('--public', action='store_true', help='make track public')
     upload_parser.add_argument('--compress', action='store_true', help='compress file')
-    upload_parser.add_argument('--no-compress', action='store_false', help='do not compress file')
-    upload_parser.set_defaults(compress=True)
     upload_parser.add_argument('--downloadable', action='store_true', help='allow downloads')
     upload_parser.add_argument('--no-downloadable', action='store_false', help='disallow downloads')
     upload_parser.set_defaults(downloadable=True)


### PR DESCRIPTION
Regardless of whether you provide --compress or --no-compress, `sc upload` proceeds with compressing the file. This change makes `sc upload` not compress by default. Soundcloud limits users by time, not file size, so my argument is to not compress by default and upload the original file. Bandwidth may be a concern, but then you can use `sc upload --compress`! Also, I don't believe Soundcloud compresses files by default (not in regards to streaming, but when somebody hits the download link on your track) -- I may be wrong here.

I'm also up for making it compress by default, but make the --no-compress option work and resend a pull request if you'd prefer. Just let me know.

Anyways, thanks for working on this. I just stumbled across this today -- looks good and simple.
