### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/soundcloud_cli/api/upload.py
+++ b/soundcloud_cli/api/upload.py
@@ -37,7 +37,7 @@ class BufferReader(BytesIO):
             try:
                 self._callback(self._len, self._progress)
             except Exception as e:
-                print e
+                print(e)
                 raise CancelledError('The upload was cancelled.')
         return chunk
 
@@ -100,9 +100,9 @@ def upload(filename, sharing='private', downloadable=True, title=None, descripti
     if res.ok:
         res = res.json()
     else:
-        print res.status_code
-        print res.headers
-        print res.text
+        print(res.status_code)
+        print(res.headers)
+        print(res.text)
         return
 
     if sharing == 'private':


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.